### PR TITLE
修复at24cxx_write只能写入第一个字节问题

### DIFF
--- a/at24cxx.c
+++ b/at24cxx.c
@@ -317,20 +317,15 @@ rt_err_t at24cxx_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffe
     {
         while (1) //NumToWrite--
         {
-            if (at24cxx_write_one_byte(dev, WriteAddr, pBuffer[i]) != RT_EOK)
-            {
-                rt_thread_mdelay(EE_TWR);
-            }
-            else
+            if (at24cxx_write_one_byte(dev, WriteAddr, pBuffer[i]) == RT_EOK)
             {
                 WriteAddr++;
-                i++;
             }
-            if (i == NumToWrite)
+            if (++i == NumToWrite)
             {
                 break;
             }
-
+            rt_thread_mdelay(EE_TWR);
         }
     }
     else


### PR DESCRIPTION
at24cxx_write中写入正确后没有延迟，导致后续写入失败。