### PR TITLE
refactor(at24cxx): 将 EEPROM 参数宏移至头文件对外暴露

### DIFF
--- a/at24cxx.c
+++ b/at24cxx.c
@@ -27,38 +27,6 @@
 #ifdef PKG_USING_AT24CXX
 #define AT24CXX_ADDR (0xA0 >> 1)                      //A0 A1 A2 connect GND
 
-#if (PKG_AT24CXX_EE_TYPE == AT24C01)
-    #define AT24CXX_PAGE_BYTE               8
-    #define AT24CXX_MAX_MEM_ADDRESS         128
-#elif (PKG_AT24CXX_EE_TYPE == AT24C02)
-    #define AT24CXX_PAGE_BYTE               8
-    #define AT24CXX_MAX_MEM_ADDRESS         256
-#elif (PKG_AT24CXX_EE_TYPE == AT24C04)
-    #define AT24CXX_PAGE_BYTE               16
-    #define AT24CXX_MAX_MEM_ADDRESS         512
-#elif (PKG_AT24CXX_EE_TYPE == AT24C08)
-    #define AT24CXX_PAGE_BYTE               16
-    #define AT24CXX_MAX_MEM_ADDRESS         1024
-#elif (PKG_AT24CXX_EE_TYPE == AT24C16)
-    #define AT24CXX_PAGE_BYTE               16
-    #define AT24CXX_MAX_MEM_ADDRESS         2048
-#elif (PKG_AT24CXX_EE_TYPE == AT24C32)
-    #define AT24CXX_PAGE_BYTE               32
-    #define AT24CXX_MAX_MEM_ADDRESS         4096
-#elif (PKG_AT24CXX_EE_TYPE == AT24C64)
-    #define AT24CXX_PAGE_BYTE               32
-    #define AT24CXX_MAX_MEM_ADDRESS         8192
-#elif (PKG_AT24CXX_EE_TYPE == AT24C128)
-    #define AT24CXX_PAGE_BYTE               64
-    #define AT24CXX_MAX_MEM_ADDRESS         16384
-#elif (PKG_AT24CXX_EE_TYPE == AT24C256)
-    #define AT24CXX_PAGE_BYTE               64
-    #define AT24CXX_MAX_MEM_ADDRESS         32768
-#elif (PKG_AT24CXX_EE_TYPE == AT24C512)
-    #define AT24CXX_PAGE_BYTE               128
-    #define AT24CXX_MAX_MEM_ADDRESS         65536
-#endif
-
 static rt_err_t read_regs(at24cxx_device_t dev, rt_uint8_t len, rt_uint8_t *buf)
 {
     struct rt_i2c_msg msgs;

--- a/at24cxx.h
+++ b/at24cxx.h
@@ -39,6 +39,38 @@
 #define AT24CXX_A1  (1 << 1)
 #define AT24CXX_A2  (1 << 2)
 
+#if (PKG_AT24CXX_EE_TYPE == AT24C01)
+    #define AT24CXX_PAGE_BYTE               8
+    #define AT24CXX_MAX_MEM_ADDRESS         128
+#elif (PKG_AT24CXX_EE_TYPE == AT24C02)
+    #define AT24CXX_PAGE_BYTE               8
+    #define AT24CXX_MAX_MEM_ADDRESS         256
+#elif (PKG_AT24CXX_EE_TYPE == AT24C04)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         512
+#elif (PKG_AT24CXX_EE_TYPE == AT24C08)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         1024
+#elif (PKG_AT24CXX_EE_TYPE == AT24C16)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         2048
+#elif (PKG_AT24CXX_EE_TYPE == AT24C32)
+    #define AT24CXX_PAGE_BYTE               32
+    #define AT24CXX_MAX_MEM_ADDRESS         4096
+#elif (PKG_AT24CXX_EE_TYPE == AT24C64)
+    #define AT24CXX_PAGE_BYTE               32
+    #define AT24CXX_MAX_MEM_ADDRESS         8192
+#elif (PKG_AT24CXX_EE_TYPE == AT24C128)
+    #define AT24CXX_PAGE_BYTE               64
+    #define AT24CXX_MAX_MEM_ADDRESS         16384
+#elif (PKG_AT24CXX_EE_TYPE == AT24C256)
+    #define AT24CXX_PAGE_BYTE               64
+    #define AT24CXX_MAX_MEM_ADDRESS         32768
+#elif (PKG_AT24CXX_EE_TYPE == AT24C512)
+    #define AT24CXX_PAGE_BYTE               128
+    #define AT24CXX_MAX_MEM_ADDRESS         65536
+#endif
+
 struct at24cxx_device
 {
     struct rt_i2c_bus_device *i2c;


### PR DESCRIPTION
## 概要

本 PR 将 `AT24CXX_PAGE_BYTE` 和 `AT24CXX_MAX_MEM_ADDRESS` 的定义
从 `at24cxx.c` 移动到 `at24cxx.h`，使相关参数能够对外可见。

这样其他依赖 AT24CXX 的模块无需再自行重复定义页大小和最大地址，
只需包含头文件即可根据 EEPROM 类型直接获取对应配置。

## 修改内容

- 将不同 EEPROM 型号对应的：
  - `AT24CXX_PAGE_BYTE`
  - `AT24CXX_MAX_MEM_ADDRESS`
  宏定义从 `at24cxx.c` 挪到 `at24cxx.h`
- 保持原有宏取值不变
- 不涉及读写流程和驱动功能逻辑修改

## 修改目的

- 对外暴露 AT24CXX 设备基础参数
- 避免其他模块重复维护相同定义
- 降低重复代码和配置不一致风险
- 方便外部模块基于 EEPROM 类型直接进行容量和页写相关处理

## 影响范围

- `Third_Party/at24cxx/at24cxx.c`
- `Third_Party/at24cxx/at24cxx.h`

## 测试说明

- 已确认本次修改仅为宏定义位置调整
- 宏值本身未发生变化
- 不影响现有 AT24CXX 驱动逻辑
- 外部模块包含 `at24cxx.h` 后可直接使用相关参数定义

## 风险评估

风险较低。

本次变更不修改驱动行为，仅扩大宏定义可见范围。