### PR TITLE
feat[AT24CXX]: 添加原始 EEPROM dump 命令

### DIFF
--- a/at24cxx.c
+++ b/at24cxx.c
@@ -110,7 +110,7 @@ static rt_err_t at24cxx_read_page(at24cxx_device_t dev, uint32_t readAddr, uint8
     msgs[1].buf = pBuffer;
     msgs[1].len = numToRead;
 
-    if(rt_i2c_transfer(dev->i2c, msgs, 2) <= 0)
+    if(rt_i2c_transfer(dev->i2c, msgs, 2) != 2)
     {
         return RT_ERROR;
     }
@@ -142,7 +142,7 @@ static rt_err_t at24cxx_write_page(at24cxx_device_t dev, uint32_t wirteAddr, uin
     msgs[1].buf = pBuffer;
     msgs[1].len = numToWrite;
 
-    if(rt_i2c_transfer(dev->i2c, msgs, 2) <= 0)
+    if(rt_i2c_transfer(dev->i2c, msgs, 2) != 2)
     {
         return RT_ERROR;
     }
@@ -291,6 +291,11 @@ rt_err_t at24cxx_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffe
                 rt_thread_mdelay(2);
                 WriteAddr++;
             }
+            else
+            {
+                result = -RT_ERROR;
+                break;
+            }
             if (++i == NumToWrite)
             {
                 break;
@@ -304,7 +309,7 @@ rt_err_t at24cxx_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffe
     }
     rt_mutex_release(dev->lock);
 
-    return RT_EOK;
+    return result;
 }
 
 /**
@@ -456,6 +461,70 @@ void at24cxx_deinit(at24cxx_device_t dev)
 }
 
 #ifdef PKG_AT24CXX_FINSH
+/** Number of EEPROM bytes printed per dump line. */
+#define AT24CXX_DUMP_LINE_BYTES         16U
+
+/**
+ * @brief Dump raw bytes from the AT24CXX EEPROM.
+ *
+ * @param dev AT24CXX device handle.
+ * @param addr EEPROM physical start address.
+ * @param length Number of bytes to dump.
+ *
+ * @return RT_EOK on success, otherwise RT_ERROR.
+ */
+static rt_err_t at24cxx_dump_data(at24cxx_device_t dev, uint32_t addr, uint32_t length)
+{
+    uint8_t buf[AT24CXX_DUMP_LINE_BYTES];
+    uint32_t remain;
+
+    RT_ASSERT(dev);
+
+    if ((length == 0U) || (addr >= AT24CXX_MAX_MEM_ADDRESS) ||
+        (length > (AT24CXX_MAX_MEM_ADDRESS - addr)))
+    {
+        rt_kprintf("Usage: at24cxx dump [addr] [len]\n");
+        rt_kprintf("Example: at24cxx dump 0 32\n");
+        rt_kprintf("Range error: addr=0x%08x len=%u max=0x%08x\n", (unsigned int)addr, (unsigned int)length, (unsigned int)AT24CXX_MAX_MEM_ADDRESS);
+        return RT_ERROR;
+    }
+
+    rt_kprintf("AT24 dump: bus=%s addr_input=%u addr=0x%08x len=%u\n", dev->i2c->parent.parent.name, (unsigned int)dev->AddrInput, (unsigned int)addr, (unsigned int)length);
+
+    remain = length;
+
+    while (remain > 0U)
+    {
+        uint16_t chunk;
+        uint16_t i;
+
+        chunk = (remain > AT24CXX_DUMP_LINE_BYTES) ?
+                AT24CXX_DUMP_LINE_BYTES : (uint16_t)remain;
+
+        if (at24cxx_page_read(dev, addr, buf, chunk) != RT_EOK)
+        {
+            rt_kprintf("AT24 dump read failed at 0x%08x len=%u\n",
+                       (unsigned int)addr,
+                       (unsigned int)chunk);
+            return RT_ERROR;
+        }
+
+        rt_kprintf("%08x:", (unsigned int)addr);
+
+        for (i = 0U; i < chunk; i++)
+        {
+            rt_kprintf(" %02x", buf[i]);
+        }
+
+        rt_kprintf("\n");
+
+        addr += chunk;
+        remain -= chunk;
+    }
+
+    return RT_EOK;
+}
+
 uint8_t TEST_BUFFER[] = "WELCOM TO RTT";
 #define SIZE sizeof(TEST_BUFFER)
 
@@ -467,7 +536,7 @@ void at24cxx(int argc, char *argv[])
     {
         if (!strcmp(argv[1], "probe"))
         {
-            if (argc > 2)
+            if (argc > 3)
             {
                 /* initialize the sensor when first probe */
                 if (!dev || strcmp(dev->i2c->parent.parent.name, argv[2]))
@@ -482,8 +551,31 @@ void at24cxx(int argc, char *argv[])
             }
             else
             {
-                rt_kprintf("at24cxx probe <dev_name> <AddrInput> - probe sensor by given name\n");
+                rt_kprintf("at24cxx probe <dev_name> <AddrInput> - probe eeprom by given name\n");
             }
+        }
+        else if (!strcmp(argv[1], "dump"))
+        {
+            uint32_t addr = 0U;
+            uint32_t length = 32U;
+
+            if (argc > 2)
+            {
+                addr = strtoul(argv[2], RT_NULL, 0);
+            }
+
+            if (argc > 3)
+            {
+                length = strtoul(argv[3], RT_NULL, 0);
+            }
+
+            if (dev == RT_NULL)
+            {
+                rt_kprintf("Please using 'at24cxx probe <dev_name> <AddrInput>' first\n");
+                return;
+            }
+
+            at24cxx_dump_data(dev, addr, length);
         }
         else if (!strcmp(argv[1], "read"))
         {
@@ -522,10 +614,11 @@ void at24cxx(int argc, char *argv[])
     else
     {
         rt_kprintf("Usage:\n");
-        rt_kprintf("at24cxx probe <dev_name>   - probe eeprom by given name\n");
-        rt_kprintf("at24cxx check              - check eeprom at24cxx \n");
-        rt_kprintf("at24cxx read               - read eeprom at24cxx data\n");
-        rt_kprintf("at24cxx write              - write eeprom at24cxx data\n");
+        rt_kprintf("at24cxx probe <dev_name> <AddrInput> - probe eeprom by given name\n");
+        rt_kprintf("at24cxx check                        - check eeprom at24cxx\n");
+        rt_kprintf("at24cxx read                         - read eeprom at24cxx data\n");
+        rt_kprintf("at24cxx write                        - write eeprom at24cxx data\n");
+        rt_kprintf("at24cxx dump [addr] [len]            - dump raw eeprom bytes\n");
 
     }
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

AT24CXX FinSH 命令缺少直接 dump EEPROM 原始数据的调试入口，排查存储内容时只能依赖 read/write/check 等固定测试路径，不方便按物理地址查看指定范围的数据。

同时，原有页读写 I2C 传输结果检查过宽，部分传输成功也可能被当作成功；字节写失败时 `at24cxx_write()` 也可能继续返回 `RT_EOK`，不利于调用方判断真实写入结果。

#### 你的解决方案是什么 (what is your solution)

新增 `at24cxx dump [addr] [len]` FinSH 命令，按 EEPROM 物理地址读取并打印原始字节，默认从地址 `0` dump `32` 字节，并在访问越界或长度为 0 时输出错误提示。

`dump` 不依赖自动生成的 parameter/PM 配置，要求用户先通过 `at24cxx probe <dev_name> <AddrInput>` 明确绑定 I2C bus 和 AT24CXX 地址输入。`probe` 在相同 bus 但 `AddrInput` 改变时会重新初始化设备，避免继续访问旧地址。

页读写路径要求 `rt_i2c_transfer()` 完整返回 2 条消息才视为成功；字节写失败时 `at24cxx_write()` 立即返回错误，避免隐藏写失败。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: N/A，本次为 AT24CXX package driver 命令逻辑修改，未绑定特定 BSP。

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: `PKG_USING_AT24CXX`, `PKG_AT24CXX_FINSH`，并启用目标 BSP 对应 I2C bus。

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: N/A，本地仅完成 diff 审查；提交前建议补充实际 CI 链接。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
